### PR TITLE
Build mp3 player with rust tokio and ffmpeg

### DIFF
--- a/tokio-mp3-player/Cargo.toml
+++ b/tokio-mp3-player/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "tokio-mp3-player"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+clap = { version = "4.5", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+nix = { version = "0.29", features = ["signal"] }
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+
+[profile.dev]
+panic = "unwind"
+
+[package]
+name = "tokio-mp3-player"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+thiserror = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+bytes = "1"
+ futures = "0.3"
+ tracing = "0.1"
+ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+ nix = { version = "0.29", features = ["signal"] }
+ 
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+
+[profile.dev]
+panic = "unwind"

--- a/tokio-mp3-player/README.md
+++ b/tokio-mp3-player/README.md
@@ -1,0 +1,37 @@
+# tokio-mp3-player
+
+A minimal Tokio-based CLI MP3 player that shells out to `ffmpeg` to decode and plays audio via ALSA on Linux.
+
+## Prerequisites
+
+- ffmpeg
+- ALSA (libasound2) and a working output device
+- Rust toolchain (cargo, rustc)
+
+## Install prerequisites (Debian/Ubuntu)
+
+```bash
+sudo apt-get update && sudo apt-get install -y ffmpeg libasound2 libasound2-dev build-essential pkg-config
+```
+
+## Build
+
+```bash
+cargo build --release
+```
+
+## Run
+
+```bash
+./target/release/tokio-mp3-player <file.mp3> --device default --show-progress
+```
+
+Controls (future work):
+- p: toggle pause
+- s: stop
+- q: quit
+- +: volume up
+- -: volume down
+
+This minimal version demonstrates process management and progress printing. Advanced controls can be implemented via `ffmpeg` filters or by controlling the ALSA device directly via a Rust audio library.
+

--- a/tokio-mp3-player/src/main.rs
+++ b/tokio-mp3-player/src/main.rs
@@ -1,0 +1,260 @@
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tracing::{error, info};
+
+#[derive(Parser, Debug)]
+#[command(name = "tokio-mp3-player", version, about = "Tokio-based MP3 player using ffmpeg -> ALSA")] 
+struct Cli {
+    /// Input MP3 file path
+    input: String,
+
+    /// ALSA device name (e.g., default)
+    #[arg(short = 'd', long = "device", default_value = "default")]
+    device: String,
+
+    /// Start position, e.g. 00:01:23 or seconds (float)
+    #[arg(short = 's', long = "start", default_value = "0")]
+    start: String,
+
+    /// Show ffmpeg progress
+    #[arg(long = "show-progress")]
+    show_progress: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+
+    let mut args: Vec<String> = vec!["-re".into()];
+    if cli.start != "0" {
+        args.push("-ss".into());
+        args.push(cli.start.clone());
+    }
+    args.push("-i".into());
+    args.push(cli.input.clone());
+    args.extend(vec![
+        "-vn".into(),
+        "-f".into(), "alsa".into(),
+        cli.device.clone(),
+    ]);
+
+    if cli.show_progress {
+        args.splice(0..0, ["-hide_banner".into(), "-loglevel".into(), "info".into()]);
+    } else {
+        args.splice(0..0, ["-hide_banner".into(), "-loglevel".into(), "error".into()]);
+    }
+
+    info!(?args, "Launching ffmpeg");
+
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().context("failed to spawn ffmpeg")?;
+
+    if cli.show_progress {
+        if let Some(stderr) = child.stderr.take() {
+            let mut reader = BufReader::new(stderr).lines();
+            tokio::spawn(async move {
+                while let Ok(Some(line)) = reader.next_line().await {
+                    if line.contains("time=") || line.contains("speed=") || line.contains("size=") {
+                        eprintln!("{line}");
+                    }
+                }
+            });
+        }
+    }
+
+    let status = child.wait().await?;
+    if !status.success() {
+        error!(?status, "ffmpeg exited with non-zero status");
+        anyhow::bail!("ffmpeg failed: {status}");
+    }
+    Ok(())
+}
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+#[derive(Parser, Debug)]
+#[command(name = "tokio-mp3-player", version, about = "Tokio-based MP3 player using ffmpeg -> ALSA", long_about = None)]
+struct Cli {
+    /// Input MP3 file path
+    input: String,
+
+    /// ALSA device name (e.g., default)
+    #[arg(short = d, long = "device", default_value = "default")]
+    device: String,
+
+    /// Start position, e.g. 00:01:23 or seconds (float)
+    #[arg(short = s, long = "start", default_value = "0")]
+    start: String,
+
+    /// Show ffmpeg progress
+    #[arg(long = "show-progress")]
+    show_progress: bool,
+}
+
+#[derive(Subcommand, Debug)]
+enum CommandArg {
+    /// Play (default)
+    Play,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+
+    let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel::<PlayerControl>();
+
+    let mut player = Player::new(cli.input.clone(), cli.device.clone());
+
+    if cli.show_progress {
+        player.enable_progress();
+    }
+
+    if cli.start != "0" {
+        player.set_start(cli.start.clone());
+    }
+
+    let mut handle = tokio::spawn(async move {
+        if let Err(e) = player.play().await {
+            error!(error = ?e, "Playback error");
+        }
+    });
+
+    // Simple stdin control loop: p= pause/resume, s=stop, q=quit, +=vol up, -=vol down
+    tokio::spawn(async move {
+        use tokio::io::{stdin, AsyncReadExt};
+        let mut input = stdin();
+        let mut buf = [0u8; 1];
+        loop {
+            if input.read_exact(&mut buf).await.is_err() {
+                break;
+            }
+            match buf[0] as char {
+                p => { let _ = ctrl_tx.send(PlayerControl::TogglePause);} 
+                s => { let _ = ctrl_tx.send(PlayerControl::Stop);} 
+                q => { let _ = ctrl_tx.send(PlayerControl::Quit);} 
+                + => { let _ = ctrl_tx.send(PlayerControl::VolumeUp);} 
+                - => { let _ = ctrl_tx.send(PlayerControl::VolumeDown);} 
+                _ => {}
+            }
+        }
+    });
+
+    // Consume control messages (no-op in this simplified version)
+    tokio::spawn(async move {
+        while let Some(_msg) = ctrl_rx.recv().await {
+            // In a full implementation, we would communicate with ffmpeg via filters or restart process
+        }
+    });
+
+    handle.await?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum PlayerControl {
+    TogglePause,
+    Stop,
+    Quit,
+    VolumeUp,
+    VolumeDown,
+}
+
+struct Player {
+    input_path: String,
+    alsa_device: String,
+    start: Option<String>,
+    show_progress: bool,
+}
+
+impl Player {
+    fn new(input_path: String, alsa_device: String) -> Self {
+        Self { input_path, alsa_device, start: None, show_progress: false }
+    }
+
+    fn set_start(&mut self, start: String) { self.start = Some(start); }
+    fn enable_progress(&mut self) { self.show_progress = true; }
+
+    async fn play(&mut self) -> Result<()> {
+        let mut args: Vec<String> = vec![
+            "-re".into(), // read at native rate
+        ];
+
+        if let Some(start) = &self.start {
+            args.push("-ss".into());
+            args.push(start.clone());
+        }
+
+        args.push("-i".into());
+        args.push(self.input_path.clone());
+
+        // Use ffmpeg to decode to PCM s16le stereo 44.1kHz and send to ALSA
+        args.extend(vec![
+            "-vn".into(),
+            "-f".into(), "alsa".into(),
+            self.alsa_device.clone(),
+        ]);
+
+        if self.show_progress {
+            // progress on stderr by default; use -stats_period
+            args.splice(0..0, ["-hide_banner".into(), "-loglevel".into(), "info".into()]);
+        } else {
+            args.splice(0..0, ["-hide_banner".into(), "-loglevel".into(), "error".into()]);
+        }
+
+        info!(?args, "Launching ffmpeg");
+
+        let mut cmd = Command::new("ffmpeg");
+        cmd.args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().context("failed to spawn ffmpeg")?;
+
+        if self.show_progress {
+            if let Some(stderr) = child.stderr.take() {
+                let mut reader = BufReader::new(stderr).lines();
+                tokio::spawn(async move {
+                    while let Ok(Some(line)) = reader.next_line().await {
+                        if line.contains("time=") || line.contains("speed=") || line.contains("size=") {
+                            eprintln!("{line}");
+                        }
+                    }
+                });
+            }
+        }
+
+        let status = child.wait().await?;
+        if !status.success() {
+            anyhow::bail!("ffmpeg exited with status: {:?}", status);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implement a minimal Tokio-based MP3 player using `ffmpeg` to play audio to ALSA, with CLI arguments for input, device, start time, and progress display.

---
<a href="https://cursor.com/background-agent?bcId=bc-116f4e06-d1d8-4de3-bb5d-6e51bcf1911f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-116f4e06-d1d8-4de3-bb5d-6e51bcf1911f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

